### PR TITLE
[PAD-129]  Fixing test failures caused by inconsistent starting states.

### DIFF
--- a/pentaho-aggdesigner-ui/test-src/org/pentaho/aggdes/ui/ConnectionControllerITest.java
+++ b/pentaho-aggdesigner-ui/test-src/org/pentaho/aggdes/ui/ConnectionControllerITest.java
@@ -140,6 +140,8 @@ public class ConnectionControllerITest extends JMock {
       provider.setXulDomContainer(container);
       provider.setBindingFactory(proxy);
     }
+    // this model gets reused across tests.  Revert to default value.
+    model.setApplySchemaSourceEnabled( false );
   }
 
   @Test

--- a/pentaho-aggdesigner-ui/test-src/org/pentaho/aggdes/ui/MainControllerTest.java
+++ b/pentaho-aggdesigner-ui/test-src/org/pentaho/aggdes/ui/MainControllerTest.java
@@ -50,6 +50,8 @@ public class MainControllerTest extends TestCase {
     } catch (Exception e) {
     	e.printStackTrace();
     }
+    XulMessageBoxStub.openedMessageBoxes.clear();
+    XulMessageBoxStub.returnCode = 0;
   }
 
   public void testSaveWorkspace() throws Exception {


### PR DESCRIPTION
There was order dependency baked into these tests; some shared objects were not being reset.
