### PR TITLE
[PPP-3735] - Use of vulnerable component httpclient-3.0.1.jar, common…

### DIFF
--- a/pentaho-aggdesigner-ui/pom.xml
+++ b/pentaho-aggdesigner-ui/pom.xml
@@ -81,18 +81,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.1</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>commons-codec</artifactId>
-          <groupId>commons-codec</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>dom4j</groupId>
       <artifactId>dom4j</artifactId>
       <version>1.6.1</version>
@@ -291,6 +279,10 @@
           <groupId>org.tukaani</groupId>
         </exclusion>
         <exclusion>
+          <artifactId>commons-httpclient</artifactId>
+          <groupId>commons-httpclient</groupId>
+        </exclusion>
+        <exclusion>
           <artifactId>batik-svggen</artifactId>
           <groupId>org.apache.xmlgraphics</groupId>
         </exclusion>
@@ -445,6 +437,10 @@
         <exclusion>
           <artifactId>jersey-servlet</artifactId>
           <groupId>com.sun.jersey</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>commons-httpclient</artifactId>
+          <groupId>commons-httpclient</groupId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
…s-httpclient-3.1 - httpclient-4.0.1.jar, SONATYPE-2007-0004, CVE-2012-6153, CVE-2011-1498, CVE-2014-3577

 - commons-httpclient is excluded from dependencies since is not used

@pamval, could you please merge it?
 