### PR TITLE
[BACKLOG-18126] The Mac icon was being corrupted by the <filtered>tru…

### DIFF
--- a/assemblies/pad-ce/assembly/assembly.xml
+++ b/assemblies/pad-ce/assembly/assembly.xml
@@ -11,6 +11,16 @@
             <directory>${project.basedir}/assembly/resources</directory>
             <outputDirectory>aggregation-designer</outputDirectory>
             <filtered>true</filtered>
+            <excludes>
+                <exclude>**/pad.icns</exclude>
+            </excludes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/assembly/resources</directory>
+            <outputDirectory>aggregation-designer</outputDirectory>
+            <includes>
+                <include>**/pad.icns</include>
+            </includes>
         </fileSet>
         <fileSet>
             <directory>${project.build.directory}</directory>


### PR DESCRIPTION
…e</filtered> option in assembly.xml

@pentaho/kashyyyk 