### PR TITLE
[COMP-6269][BACKLOG-17518] Removing transitive Kettle deps of dbdialog

### DIFF
--- a/pentaho-aggdesigner-ui/pom.xml
+++ b/pentaho-aggdesigner-ui/pom.xml
@@ -263,9 +263,21 @@
       <scope>compile</scope>
       <exclusions>
         <exclusion>
+         <groupId>pentaho-kettle</groupId>       
+          <artifactId>kettle-core</artifactId>
+        </exclusion>     
+        <exclusion>
+          <groupId>pentaho-kettle</groupId>
+          <artifactId>kettle-engine</artifactId>
+        </exclusion>     
+        <exclusion>
+          <groupId>pentaho</groupId>
+          <artifactId>pentaho-xul-swt</artifactId>
+        </exclusion>             
+        <exclusion>
           <artifactId>*</artifactId>
           <groupId>*</groupId>
-        </exclusion>
+        </exclusion> 
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Removes transitive dependencies introduced after Maven conversion. See COMP-6269 for an example.