### PR TITLE
[PSW-229] Script files don't have an header with Copyright data

### DIFF
--- a/assemblies/pad-ce/src/main/resources/AggregationDesigner.command
+++ b/assemblies/pad-ce/src/main/resources/AggregationDesigner.command
@@ -1,3 +1,19 @@
+# This program is free software; you can redistribute it and/or modify it under the
+# terms of the GNU General Public License, version 2 as published by the Free Software
+# Foundation.
+#
+# You should have received a copy of the GNU General Public License along with this
+# program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+# or from the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+#
+# Copyright 2013 - 2017 Hitachi Vantara.  All rights reserved.
+
 cd `dirname $0`
 
 # if a BASE_DIR argument has been passed to this .command, use it

--- a/assemblies/pad-ce/src/main/resources/set-pentaho-env.bat
+++ b/assemblies/pad-ce/src/main/resources/set-pentaho-env.bat
@@ -13,7 +13,7 @@
 @REM See the GNU General Public License for more details.
 @REM
 @REM
-@REM Copyright 2010 - 2017 Pentaho Corporation.  All rights reserved.
+@REM Copyright 2010 - 2017 Hitachi Vantara.  All rights reserved.
 
 rem ---------------------------------------------------------------------------
 rem Finds a suitable Java

--- a/pentaho-aggdesigner-ui/dev-res/pad-dist.bat
+++ b/pentaho-aggdesigner-ui/dev-res/pad-dist.bat
@@ -15,7 +15,7 @@ REM Add -Dmaven.test.skip=true to skip unit tests
 @REM See the GNU General Public License for more details.
 @REM
 @REM
-@REM Copyright 2008 - 2017 Pentaho Corporation.  All rights reserved.
+@REM Copyright 2008 - 2017 Hitachi Vantara.  All rights reserved.
 
 cd ..
 mvn clean package javadoc:javadoc assembly:assembly -Dmaven.test.skip=true


### PR DESCRIPTION
- license was added
- Copyright was updated in missed scripts