### PR TITLE
[BACKLOG-13813] - Downstream updates

### DIFF
--- a/pentaho-aggdesigner-ui/pom.xml
+++ b/pentaho-aggdesigner-ui/pom.xml
@@ -27,7 +27,7 @@
     <project.revision>8.1.0.0-SNAPSHOT</project.revision>
     <mondrian.version>8.1.0.0-SNAPSHOT</mondrian.version>
     <commons-xul.version>8.1.0.0-SNAPSHOT</commons-xul.version>
-    <pentaho-mondrianschemaworkbench-plugins.version>8.1.0.0-SNAPSHOT</pentaho-mondrianschemaworkbench-plugins.version>
+    <mondrian-schemaworkbench-plugins.version>8.1.0.0-SNAPSHOT</mondrian-schemaworkbench-plugins.version>
     <dependency.junit.revision>4.12</dependency.junit.revision>
     <pentaho-launcher.version>8.1.0.0-SNAPSHOT</pentaho-launcher.version>
     <dependency.javassist.revision>3.20.0-GA</dependency.javassist.revision>
@@ -338,9 +338,9 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>pentaho</groupId>
-      <artifactId>pentaho-mondrianschemaworkbench-plugins</artifactId>
-      <version>${pentaho-mondrianschemaworkbench-plugins.version}</version>
+      <groupId>org.pentaho</groupId>
+      <artifactId>mondrian-schemaworkbench-plugins</artifactId>
+      <version>${mondrian-schemaworkbench-plugins.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
@pentaho/2-1b depends on https://github.com/pentaho/pentaho-mondrianschemaworkbench-plugins/pull/23