### PR TITLE
[PPP-4448] Use of Vulnerable Component - XStream 1.4.10

### DIFF
--- a/pentaho-aggdesigner-ui/pom.xml
+++ b/pentaho-aggdesigner-ui/pom.xml
@@ -32,7 +32,6 @@
     <pentaho-launcher.version>9.0.0.0-SNAPSHOT</pentaho-launcher.version>
     <dependency.javassist.revision>3.20.0-GA</dependency.javassist.revision>
     <pdi.version>9.0.0.0-SNAPSHOT</pdi.version>
-    <dependency.xstream.revision>1.4.10</dependency.xstream.revision>
   </properties>
 
   <dependencies>
@@ -104,14 +103,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>${dependency.xstream.revision}</version>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>pentaho</groupId>


### PR DESCRIPTION
This is part of a series of PRs. See https://github.com/pentaho/maven-parent-poms/pull/170 for details.

**Don't merge before the PR above.**

Removing the exclusions has no impact on the final assembly.