### PR TITLE
[PAD-175] - PAD startup script throws some errors (Ubuntu & MacOS)

### DIFF
--- a/assemblies/pad-ce/src/main/resources-filtered/startaggregationdesigner.sh
+++ b/assemblies/pad-ce/src/main/resources-filtered/startaggregationdesigner.sh
@@ -21,9 +21,7 @@
 # Copyright © 2008 - ${copyright.year} ${project.organization.name}
 # Classpath is built by launcher. See ../lib/launcher.properties.
 
-DIR_REL=`dirname "$0"`
-cd "$DIR_REL"
-DIR=`pwd`
+DIR=$( cd "$( dirname "$0" )" && pwd )
 
 . "$DIR/set-pentaho-env.sh"
 setPentahoEnv


### PR DESCRIPTION
Please note that this is an masOS and Ubuntu issue.

Additional PR https://github.com/pentaho/pentaho-aggdesigner-ee/pull/34

@ssamora 
@ppatricio 