### PR TITLE
[PAD-170] design-tools installed in a path containing whitespaces do …

### DIFF
--- a/assemblies/pad-ce/src/main/resources-filtered/AggregationDesigner.command
+++ b/assemblies/pad-ce/src/main/resources-filtered/AggregationDesigner.command
@@ -20,8 +20,10 @@ cd `dirname $0`
 if [ -n "$1" ] && [ -d "$1" ] && [ -x "$1" ]; then
     echo "DEBUG: Using value ($1) from calling script"
     cd "$1"
+    pwd
+    ./startaggregationdesigner.sh
+else
+    DIR=$( cd "$( dirname "$0" )"; pwd )
+    . "$DIR/startaggregationdesigner.sh"
 fi
-
-pwd
-./startaggregationdesigner.sh
 exit


### PR DESCRIPTION
…not work when its shell scripts are called from outside the design-tool's base root

@bcostahitachivantara @smmribeiro @moraesvc 