### PR TITLE
[PAD-170] design-tools installed in a path containing whitespaces do …

### DIFF
--- a/assemblies/pad-ce/src/main/resources-filtered/AggregationDesigner.command
+++ b/assemblies/pad-ce/src/main/resources-filtered/AggregationDesigner.command
@@ -14,7 +14,6 @@
 #
 # Copyright 2013 - ${copyright.year} Hitachi Vantara. All rights reserved.
 
-cd `dirname $0`
 
 # if a BASE_DIR argument has been passed to this .command, use it
 if [ -n "$1" ] && [ -d "$1" ] && [ -x "$1" ]; then


### PR DESCRIPTION
…not work when its shell scripts are called from outside the design-tool's base root

@bcostahitachivantara 