### PR TITLE
[BACKLOG-14722] Sets the assembly dependency on slf4j.

### DIFF
--- a/assemblies/pad-ce/pom.xml
+++ b/assemblies/pad-ce/pom.xml
@@ -42,9 +42,10 @@
     </dependency>
     <!-- Use log4j implementation with SLF4J -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
       <scope>runtime</scope>
+      <version>${log4j.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Do not merge yet. This cannot build until mondrian is dependent on 2.15.0.