### PR TITLE
[PPP-4982] - PAD 9.3.0.4 and above will not launch

### DIFF
--- a/pentaho-aggdesigner-core/pom.xml
+++ b/pentaho-aggdesigner-core/pom.xml
@@ -124,6 +124,10 @@
       <version>${mysql-connector-java.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>xml-apis</groupId>
+      <artifactId>xml-apis</artifactId>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>


### PR DESCRIPTION
Adding xml-apis dependency to pentaho-aggdesigner

@smmribeiro 
@renato-s 
@bcostahitachivantara 