### PR TITLE
[PPP-4982] Backport of PPP-4982 - PAD 9.3.0.4 and above will not launch (9.3 Suite)

### DIFF
--- a/pentaho-aggdesigner-core/pom.xml
+++ b/pentaho-aggdesigner-core/pom.xml
@@ -126,6 +126,10 @@
       <version>${mysql-connector-java.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>xml-apis</groupId>
+      <artifactId>xml-apis</artifactId>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>


### PR DESCRIPTION
(cherry picked from commit 6cc1a2bfdf846639ac9d031732170d56625d34c5)

Original PR: [pentaho-aggdesigner#179](https://github.com/pentaho/pentaho-aggdesigner/pull/179)

@andreramos89 @bcostahitachivantara @renato-s 