### PR TITLE
[BACKLOG-43170] Remove copyright headers from PAD, PRD, and PSW splas…

### DIFF
--- a/pentaho-aggdesigner-ui/src/main/java/org/pentaho/aggdes/ui/form/controller/MainController.java
+++ b/pentaho-aggdesigner-ui/src/main/java/org/pentaho/aggdes/ui/form/controller/MainController.java
@@ -376,10 +376,6 @@ public class MainController extends AbstractXulEventHandler {
     XulLabel helpAboutVersionLabel = (XulLabel) document.getElementById("aboutVersion");
     helpAboutVersionLabel.setValue( Messages.getString( "about_version", version ) );
 
-    XulLabel helpAboutCopyrightLabel = (XulLabel) document.getElementById( "aboutCopyright" );
-    helpAboutCopyrightLabel.setValue( Messages.getString( "about_copyright", ""
-      + ( (new Date() ).getYear()+1900 ) ) );
-
     StringBuilder license = new StringBuilder();
     String line;
     try {

--- a/pentaho-aggdesigner-ui/src/main/resources-filtered/org/pentaho/aggdes/ui/resources/mainFrame.properties
+++ b/pentaho-aggdesigner-ui/src/main/resources-filtered/org/pentaho/aggdes/ui/resources/mainFrame.properties
@@ -144,4 +144,3 @@ AlgorithmController.NoResultsTitle=No Recommendations
 AlgorithmController.NoResultsMessage=The Advisor Algorithm returned no recommendations.
 
 about_version=Version: {0}
-about_copyright=Copyright (c) 2008-{0} Hitachi Vantara.  All rights reserved.

--- a/pentaho-aggdesigner-ui/src/main/resources/org/pentaho/aggdes/ui/resources/dialogs.xul
+++ b/pentaho-aggdesigner-ui/src/main/resources/org/pentaho/aggdes/ui/resources/dialogs.xul
@@ -20,7 +20,6 @@
           <image src="images/aboutSide.png"/>
           <vbox flex="10">
             <label id="aboutVersion" value="${about_version}"/>
-            <label id="aboutCopyright" value="${about_copyright}"/>
             <spacer height="20" />
             <textbox multiline="true" id="aboutLicense" value="" flex="1" readonly="true" />
             <spacer height="50" />


### PR DESCRIPTION
…h screens, as those lines now exist in the license text

- Remove copyright label from SplashScreen and all related components that are not longer to be used