### PR TITLE
fix[PPP-6756]: add parsson exclusion to jersey-media-json-processing and explicitly declare 1.1.8 version

### DIFF
--- a/pentaho-aggdesigner-ui/pom.xml
+++ b/pentaho-aggdesigner-ui/pom.xml
@@ -33,6 +33,7 @@
     <dependency.javassist.revision>3.20.0-GA</dependency.javassist.revision>
     <pdi.version>11.1.0.0-SNAPSHOT</pdi.version>
     <jmock.version>2.4.0</jmock.version>
+    <parsson.version>1.1.8</parsson.version>
   </properties>
 
   <dependencies>
@@ -487,6 +488,26 @@
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-processing</artifactId>
       <version>${jersey.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.parsson</groupId>
+          <artifactId>parsson</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.parsson</groupId>
+          <artifactId>parsson-media</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.parsson</groupId>
+      <artifactId>parsson</artifactId>
+      <version>${parsson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.parsson</groupId>
+      <artifactId>parsson-media</artifactId>
+      <version>${parsson.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.ext</groupId>


### PR DESCRIPTION
@pentaho/tatooine_dev 