### PR TITLE
[DEVO-14362] Repoint Maven repository URLs to repo.pentaho.com (11.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <repository>
       <id>pentaho-public</id>
       <name>Pentaho Public</name>
-      <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
+      <url>https://repo.pentaho.com/artifactory/pnt-mvn/</url>
       <releases>
         <enabled>true</enabled>
         <updatePolicy>daily</updatePolicy>
@@ -49,7 +49,7 @@
     <pluginRepository>
       <id>pentaho-public-plugins</id>
       <name>Pentaho Public Plugins</name>
-      <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
+      <url>https://repo.pentaho.com/artifactory/pnt-mvn/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>


### PR DESCRIPTION
Repoints Maven repository hostnames on the `11.0` service pack line.

- `repo.orl.eng.hitachivantara.com` -> `repo.pentaho.com`
- Host-only substitution; the `/artifactory/<path>/` segment, scheme and trailing slash are preserved
- Repository `<id>`/`<name>` unchanged; no version, formatting or ordering changes
- Files changed: 1, occurrences replaced: 2
- `mvn -B validate` passes

Base is `11.0`, not the default branch. Ticket: DEVO-14362.